### PR TITLE
Add privileged chatter commands

### DIFF
--- a/plugins/privileged_chatter.py
+++ b/plugins/privileged_chatter.py
@@ -14,12 +14,16 @@ Original authors: kharidiron
 # TODO: This whole plugin
 
 from base_plugin import SimpleCommandPlugin
-from utilities import get_syntax, Command, send_message
+from plugins.player_manager import Moderator
+from utilities import get_syntax, Command, send_message, ChatReceiveMode
 
+class ModeratorChat(Moderator):
+    pass
 
 class PrivilegedChatter(SimpleCommandPlugin):
     name = "privileged_chatter"
-    depends = ["command_dispatcher"]
+    depends = ["command_dispatcher", "chat_enhancements", "player_manager"]
+    default_config = {"modchat_color": "^red;"}
 
     def __init__(self):
         super().__init__()
@@ -31,22 +35,31 @@ class PrivilegedChatter(SimpleCommandPlugin):
         cd = self.plugins.command_dispatcher
         self.command_prefix = cd.plugin_config.command_prefix
         self.commands = cd.commands
+        self.modchat_color = self.config.get_plugin_config(self.name)["modchat_color"]
 
     # Commands - In-game actions that can be performed
 
-    # @Command("em",
-    #          doc="Perform emote actions.")
-    # def _emote(self, data, connection):
-    #     """
-    #     Command to provide in-game text emotes.
-    #
-    #     :param data: The packet containing the command.
-    #     :param connection: The connection which sent the command.
-    #     :return: Null.
-    #     """
-    #     if not data:
-    #         # list emotes available to player
-    #         pass
-    #     else:
-    #         # perform emote
-    #         pass
+    @Command("modchat", "m",
+              role=ModeratorChat,
+              doc="Send a message that can only be seen by other moderators.")
+    def _moderatorchat(self, data, connection):
+         """
+         Command to send private messages between moderators.
+
+         :param data: The packet containing the command.
+         :param connection: The connection which sent the command.
+         :return: Null.
+         """
+         if data:
+             message = " ".join(data)
+             sender = self.plugins['chat_enhancements']._decorate_line(connection)
+             send_mode = ChatReceiveMode.BROADCAST
+             channel = ""
+             for p in self.factory.connections:
+                 if "ModeratorChat" in p.player.roles:
+                     yield from send_message(p,
+                                             "{}{}^reset;".format(self.modchat_color, message),
+                                             client_id=p.player.client_id,
+                                             name=sender,
+                                             mode=send_mode,
+                                             channel=channel)

--- a/plugins/privileged_chatter.py
+++ b/plugins/privileged_chatter.py
@@ -11,8 +11,6 @@ Add a number of chat commands that leverage the roles system:
 Original authors: kharidiron
 """
 
-# TODO: This whole plugin
-
 from base_plugin import SimpleCommandPlugin
 from plugins.player_manager import Moderator
 from utilities import get_syntax, Command, send_message, ChatReceiveMode
@@ -23,7 +21,8 @@ class ModeratorChat(Moderator):
 class PrivilegedChatter(SimpleCommandPlugin):
     name = "privileged_chatter"
     depends = ["command_dispatcher", "chat_enhancements", "player_manager"]
-    default_config = {"modchat_color": "^red;"}
+    default_config = {"modchat_color": "^red;",
+                      "report_prefix": "^red;(REPORT): "}
 
     def __init__(self):
         super().__init__()
@@ -36,6 +35,7 @@ class PrivilegedChatter(SimpleCommandPlugin):
         self.command_prefix = cd.plugin_config.command_prefix
         self.commands = cd.commands
         self.modchat_color = self.config.get_plugin_config(self.name)["modchat_color"]
+        self.report_prefix = self.config.get_plugin_config(self.name)["report_prefix"]
 
     # Commands - In-game actions that can be performed
 
@@ -59,6 +59,30 @@ class PrivilegedChatter(SimpleCommandPlugin):
                  if "ModeratorChat" in p.player.roles:
                      yield from send_message(p,
                                              "{}{}^reset;".format(self.modchat_color, message),
+                                             client_id=p.player.client_id,
+                                             name=sender,
+                                             mode=send_mode,
+                                             channel=channel)
+
+    @Command("report",
+          doc="Privately make a report to all online moderators.")
+    def _moderatorchat(self, data, connection):
+         """
+         Command to send reports to moderators.
+
+         :param data: The packet containing the command.
+         :param connection: The connection which sent the command.
+         :return: Null.
+         """
+         if data:
+             message = " ".join(data)
+             sender = self.plugins['chat_enhancements']._decorate_line(connection)
+             send_mode = ChatReceiveMode.BROADCAST
+             channel = ""
+             for p in self.factory.connections:
+                 if "ModeratorChat" in p.player.roles or p == connection:
+                     yield from send_message(p,
+                                             "{}{}^reset;".format(self.report_prefix, message),
                                              client_id=p.player.client_id,
                                              name=sender,
                                              mode=send_mode,

--- a/plugins/privileged_chatter.py
+++ b/plugins/privileged_chatter.py
@@ -22,7 +22,7 @@ class PrivilegedChatter(SimpleCommandPlugin):
     name = "privileged_chatter"
     depends = ["command_dispatcher", "chat_enhancements", "player_manager"]
     default_config = {"modchat_color": "^violet;",
-                      "report_prefix": "^red;(REPORT): "}
+                      "report_prefix": "^magenta;(REPORT): "}
 
     def __init__(self):
         super().__init__()

--- a/plugins/privileged_chatter.py
+++ b/plugins/privileged_chatter.py
@@ -21,7 +21,7 @@ class ModeratorChat(Moderator):
 class PrivilegedChatter(SimpleCommandPlugin):
     name = "privileged_chatter"
     depends = ["command_dispatcher", "chat_enhancements", "player_manager"]
-    default_config = {"modchat_color": "^red;",
+    default_config = {"modchat_color": "^violet;",
                       "report_prefix": "^red;(REPORT): "}
 
     def __init__(self):


### PR DESCRIPTION
Includes /modchat (/m) for chat between moderators and /report for reporting issues to moderators.
Closes #11.
