### PR TITLE
Improve name sanitization

### DIFF
--- a/plugins/general_commands.py
+++ b/plugins/general_commands.py
@@ -188,7 +188,7 @@ class GeneralCommands(SimpleCommandPlugin):
         if self.plugins.player_manager.get_player_by_alias(alias):
             raise ValueError("There's already a user by that name.")
         else:
-            clean_alias = self.plugins['player_manager']._clean_name(alias)
+            clean_alias = self.plugins['player_manager'].clean_name(alias)
             if clean_alias is None:
                 send_message(connection,
                              "Nickname contains no valid characters.")

--- a/plugins/general_commands.py
+++ b/plugins/general_commands.py
@@ -189,6 +189,10 @@ class GeneralCommands(SimpleCommandPlugin):
             raise ValueError("There's already a user by that name.")
         else:
             clean_alias = self.plugins['player_manager']._clean_name(alias)
+            if clean_alias is None:
+                send_message(connection,
+                             "Nickname contains no valid characters.")
+                return
             old_alias = connection.player.alias
             connection.player.alias = clean_alias
             broadcast(self.factory,

--- a/plugins/player_manager.py
+++ b/plugins/player_manager.py
@@ -452,7 +452,7 @@ class PlayerManager(SimpleCommandPlugin):
         self.players_online.remove(connection.player.uuid)
         return True
 
-    def _clean_name(self, name):
+    def clean_name(self, name):
         color_strip = re.compile("\^(.*?);")
         alias = color_strip.sub("", name)
         non_ascii_strip = re.compile("[^ -~]")
@@ -670,7 +670,7 @@ class PlayerManager(SimpleCommandPlugin):
             uuid = uuid.decode("ascii")
         if isinstance(name, bytes):
             name = name.decode("utf-8")
-        alias = self._clean_name(name)
+        alias = self.clean_name(name)
         if alias is None:
             alias = uuid[0:4]
 

--- a/plugins/player_manager.py
+++ b/plugins/player_manager.py
@@ -455,7 +455,14 @@ class PlayerManager(SimpleCommandPlugin):
     def _clean_name(self, name):
         color_strip = re.compile("\^(.*?);")
         alias = color_strip.sub("", name)
-        return alias
+        non_ascii_strip = re.compile("[^\x00-\x7F]")
+        alias = non_ascii_strip.sub("", alias)
+        multi_whitespace_strip = re.compile("[ ]{2,}")
+        alias = multi_whitespace_strip.sub(" ", alias)
+        if non_ascii_strip.search(alias) is None:
+            return None
+        else:
+            return alias
 
     def build_rejection(self, reason):
         """
@@ -662,6 +669,8 @@ class PlayerManager(SimpleCommandPlugin):
         if isinstance(name, bytes):
             name = name.decode("utf-8")
         alias = self._clean_name(name)
+        if alias is None:
+            alias = uuid[0:4]
 
         if uuid in self.shelf["players"]:
             self.logger.info("Known player is attempting to log in: "

--- a/plugins/player_manager.py
+++ b/plugins/player_manager.py
@@ -455,13 +455,15 @@ class PlayerManager(SimpleCommandPlugin):
     def _clean_name(self, name):
         color_strip = re.compile("\^(.*?);")
         alias = color_strip.sub("", name)
-        non_ascii_strip = re.compile("[^\x00-\x7F]")
+        non_ascii_strip = re.compile("[^ -~]")
         alias = non_ascii_strip.sub("", alias)
-        multi_whitespace_strip = re.compile("[ ]{2,}")
+        multi_whitespace_strip = re.compile("[\s]{2,}")
         alias = multi_whitespace_strip.sub(" ", alias)
-        if non_ascii_strip.search(alias) is None:
+        match_non_whitespace = re.compile("[\S]")
+        if match_non_whitespace.search(alias) is None:
             return None
         else:
+            if len(alias) > 20: alias = alias[0:20]
             return alias
 
     def build_rejection(self, reason):

--- a/plugins/poi.py
+++ b/plugins/poi.py
@@ -68,7 +68,8 @@ class POI(StorageCommandPlugin):
     # Commands - In-game actions that can be performed
 
     @Command("poi",
-             doc="Moves a player's ship to the specified Point of Interest, or prints the POIs if no argument given.",
+             doc="Moves a player's ship to the specified Point of Interest, or "
+                 "prints the POIs if no argument given.",
              syntax="[\"][POI name][\"]")
     def _poi(self, data, connection):
         """


### PR DESCRIPTION
Removes multiple whitespace and non-ascii characters. Truncates names to a maximum of twenty characters in length. If name contains no valid characters, player is assigned the first four characters of their UUID as an alias.
